### PR TITLE
Use default font for all pages

### DIFF
--- a/_sass/minima/_layout.scss
+++ b/_sass/minima/_layout.scss
@@ -243,13 +243,6 @@
 .post-content {
   margin-bottom: $spacing-unit;
 
-  // font-family: Georgia, Cambria, "Times New Roman", Times, serif;
-  // font-style: normal;
-  // font-weight: 400;
-  // font-size: 18px;
-  // line-height: 1.58;
-  // letter-spacing: -.003em;
-
   h2 {
     @include relative-font-size(2);
 

--- a/_sass/minima/_layout.scss
+++ b/_sass/minima/_layout.scss
@@ -243,12 +243,12 @@
 .post-content {
   margin-bottom: $spacing-unit;
 
-  font-family: Georgia, Cambria, "Times New Roman", Times, serif;
-  font-style: normal;
-  font-weight: 400;
-  font-size: 18px;
-  line-height: 1.58;
-  letter-spacing: -.003em;
+  // font-family: Georgia, Cambria, "Times New Roman", Times, serif;
+  // font-style: normal;
+  // font-weight: 400;
+  // font-size: 18px;
+  // line-height: 1.58;
+  // letter-spacing: -.003em;
 
   h2 {
     @include relative-font-size(2);


### PR DESCRIPTION
Use default font for all pages by removing custom font definition in layout css

See preview of result here: https://nielsdrost.github.io/openda-association.github.io/

Note the preview has some broken image links due to the site assuming it is hosted at the website root.